### PR TITLE
document why and when --no-build-isolation is used in wheel-building CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -43,12 +43,16 @@ Some RAPIDS packages are pure Python and simply depend on other packages for com
 Those packages do not contain any Cython or CMake, and instead using `setuptools`.
 
 To build and install Python packages, you follow the same approach used to build any normal Python package:
+
+```shell
+python -m pip install /path/to/project
 ```
-python -m pip install --no-build-isolation /path/to/project
-```
+
 where `/path/to/project` is the path to a directory containing a `pyproject.toml` file.
-Note the specification of `--no-build-isolation` above; this assumes that you have already installed all the Cython and C++ build dependencies of your project into your environment.
-Currently this is a requirement of RAPIDS builds, which are not able to correctly specify the Python package requirements, [but this will be fixed in the future with the rapids-build-backend](packaging.md#pyproject).
+
+By default, this will create an isolated build environment... a temporary directory containing all of the build-time dependencies of the package.
+That's convenient because it means that you don't have to manually install the build dependencies ahead of time or deal with conflicts
+between those dependencies and other things in your development environment.
 
 ## build.sh scripts
 

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -50,9 +50,7 @@ python -m pip install /path/to/project
 
 where `/path/to/project` is the path to a directory containing a `pyproject.toml` file.
 
-By default, this will create an isolated build environment... a temporary directory containing all of the build-time dependencies of the package.
-That's convenient because it means that you don't have to manually install the build dependencies ahead of time or deal with conflicts
-between those dependencies and other things in your development environment.
+By default, this will create an isolated build environment, and `rapids-build-backend` will ensure that the necessary build-time dependencies are installed in that environment.
 
 ## build.sh scripts
 

--- a/docs/docs/ci.md
+++ b/docs/docs/ci.md
@@ -31,9 +31,9 @@ The filepaths for files used in the build are considered as part of `sccache`'s 
 
 To minimize the impact of this, since https://github.com/rapidsai/build-planning/issues/108 RAPIDS wheel-building scripts in CI have followed these rules:
 
-* pure Python? (e.g. `dask-cuda`) build isolation
-* Python + Cython? (e.g. `ucxx`) build isolation
-* mostly C / C++? (e.g. `libcudf`) no build isolation
+* pure Python (e.g. `dask-cuda`): build isolation
+* Python & Cython (e.g. `ucxx`): build isolation
+* mostly C++ (e.g. `libcudf`): no build isolation
 
 This pattern is followed to balance these two competing concerns:
 

--- a/docs/docs/ci.md
+++ b/docs/docs/ci.md
@@ -39,6 +39,7 @@ This pattern is followed to balance these two competing concerns:
 
 * improved cache hit rates for `sccache`, and therefore faster and less resource-intensive builds
 * testing that `rapids-build-backend` correctly generates package metadata
+* ensuring that the default approach for local builds from source (with isolation) will work out of the box for the non-C++ packages
 
 Without build isolation, all build-time dependencies have to be installed manually before invoking a wheel-building backend.
 That is why in `build_wheel_{lib}.sh` scripts, you'll often see a pattern similar to this:

--- a/docs/docs/packaging.md
+++ b/docs/docs/packaging.md
@@ -65,13 +65,9 @@ These suffixes are part of the package name, but they don't change the import na
 Each package will contain roughly the same contents, just built with different CUDA versions.
 In other words, `cudf-cu11` and `cudf-cu12` should not be installed together in the same environment, because they will clobber each other and cause unpredictable results.
 
-This difficulty is the reason why [the section on building Python packages recommended turning off build isolation](building.md#python-packages).
 The default dependency list specified in `pyproject.toml` for our packages does not contain the necessary suffix, and will therefore be incorrect.
-However, the correct dependency list may be generated using DFG, and that `requirements.txt` file can be installed into the environment by the developer.
-When we build wheels for distribution, we modify the metadata in `pyproject.toml` directly before building the package to address the above concerns.
-These modifications can be seen in our CI scripts: for instance, [you can see that cudf changes `rmm` to `rmm-cu11` or `rmm-cu12` with sed in its wheel building scripts](https://github.com/rapidsai/cudf/blob/branch-24.06/ci/build_wheel.sh#L42).
-If developers wish to build and/or install a specific RAPIDS wheel locally, they will have to make similar modifications.
-In the future, this will be fixed with the [`rapids-build-backend`](https://github.com/rapidsai/rapids-build-backend/) a PEP 517 build backend wrapper that essentially provides the glue between DFG and the underlying build backend (typically `scikit-build-core` or `setuptools`), ensuring that when a Python package is built the appropriate suffixes are added.
+However, the correct dependency list is generated at wheel-building time using [`rapids-build-backend`](https://github.com/rapidsai/rapids-build-backend/), a PEP 517
+build backend wrapper that provides the glue between `rapids-dependency-file-generator` and the build backend (typically `scikit-build-core` or `setuptools`).
 
 ## Nightlies
 


### PR DESCRIPTION
Contributes to #108

* documents why and when `--no-build-isolation` is used in wheel-building CI
* removes outdated information about how to build wheels locally (because we have `rapids-build-backend-now` 😀 )
* adds a `pre-commit` config, to fix file endings and trailing whitespace

## Notes for Reviewers

I've marked this `DO NOT MERGE` because it's describing as current state changes that haven't actually been made yet... it shouldn't be merged until most of #108 is done.

But it's ready for review.